### PR TITLE
Help command.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,9 @@
       "ignoreReadBeforeAssign": false
     }],
     "space-before-blocks": "error",
-    "space-before-function-paren": "off"
+    "space-before-function-paren": "off",
+  },
+  "env": {
+    "jest": true
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -2,15 +2,23 @@ const { Client, Collection } = require('discord.js');
 const fs = require('fs-extra');
 const path = require('path');
 const appHandlers = require('./events/handlers/app');
+const constants = require('./common/constants');
 const config = require('../config/settings.json');
 
 const client = new Client();
+client.commands = {};
 
-client.commands = new Collection();
-const commandFiles = fs.readdirSync(path.join(__dirname, '/commands')).filter(file => file.endsWith('.js'));
-for (const file of commandFiles) {
-  const command = require(`./commands/${file}`);
-  client.commands.set(command.name, command);
+function loadCommands(type) {
+  client.commands[type] = new Collection();
+  const commandFiles = fs.readdirSync(path.join(__dirname, '/commands/', type)).filter(file => file.endsWith('.js'));
+  for (const file of commandFiles) {
+    const command = require(`./commands/${type}/${file}`);
+    client.commands[type].set(command.name, command);
+  }
+}
+
+for (const type of constants.COMMAND_TYPES) {
+  loadCommands(type);
 }
 
 client.on('ready', () => appHandlers.handleReady(client));

--- a/src/commands/common/common.js
+++ b/src/commands/common/common.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'common',
+  description: 'A sample ping command. Should work in guilds and DM.',
+  execute(message, options) {
+    message.reply('Common!');
+  }
+};

--- a/src/commands/common/help.js
+++ b/src/commands/common/help.js
@@ -1,0 +1,44 @@
+const { MessageEmbed } = require('discord.js');
+const { prefix } = require('../../../config/settings.json');
+const utils = require('../../utils');
+const { MESSAGE_EMBED_COLOR, MESSAGE_EMBED_HELP_THUMBNAIL } = require('../../common/constants');
+
+function processCommands(commands) {
+  const commandMessages = [];
+
+  for (const command of commands) {
+    commandMessages.push(`**${prefix}${command[1].name}** - ${command[1].description}\n`);
+  }
+
+  return commandMessages;
+}
+
+module.exports = {
+  name: 'help',
+  description: 'A help message to display all the commands available to the user.',
+  execute(message, options) {
+    let messageOrigin = null;
+    let commandsCollection = null;
+
+    if (message.guild) {
+      messageOrigin = 'Guild';
+      commandsCollection = options.commands.guild.concat(options.commands.common);
+    } else {
+      messageOrigin = 'DM';
+      commandsCollection = options.commands.dm.concat(options.commands.common);
+    }
+
+    const commands = processCommands(commandsCollection);
+    const splittedMessage = utils.common.splitForMessageEmbedField(commands);
+
+    const embed = new MessageEmbed()
+      .setTitle(`A list of available ${messageOrigin} commands:`)
+      .setColor(MESSAGE_EMBED_COLOR)
+      .setThumbnail(MESSAGE_EMBED_HELP_THUMBNAIL);
+    for (let i = 0; i < splittedMessage.length; i++) {
+      embed.addField(`Page ${i + 1}:`, splittedMessage[i]);
+    }
+
+    message.channel.send(embed);
+  }
+};

--- a/src/commands/dm/dm.js
+++ b/src/commands/dm/dm.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'dm',
+  description: 'A sample ping command. Should only work in DM.',
+  execute(message, options) {
+    message.reply('DM!');
+  }
+};

--- a/src/commands/guild/guild.js
+++ b/src/commands/guild/guild.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'guild',
+  description: 'A sample ping command. Should only work in guilds.',
+  execute(message, options) {
+    message.reply('Guild!');
+  }
+};

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,7 +1,0 @@
-module.exports = {
-  name: 'ping',
-  description: 'A sample ping command.',
-  execute(message, options) {
-    message.reply('Pong!');
-  }
-};

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,0 +1,5 @@
+const COMMAND_TYPES = ['common', 'guild', 'dm'];
+
+module.exports = {
+  COMMAND_TYPES
+};

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,5 +1,11 @@
 const COMMAND_TYPES = ['common', 'guild', 'dm'];
+const MAX_EMBED_FIELD_SIZE = 1024;
+const MESSAGE_EMBED_COLOR = 'YELLOW';
+const MESSAGE_EMBED_HELP_THUMBNAIL = 'https://i.imgur.com/Tqnk48j.png';
 
 module.exports = {
-  COMMAND_TYPES
+  COMMAND_TYPES,
+  MAX_EMBED_FIELD_SIZE,
+  MESSAGE_EMBED_COLOR,
+  MESSAGE_EMBED_HELP_THUMBNAIL
 };

--- a/src/events/handlers/app.js
+++ b/src/events/handlers/app.js
@@ -1,5 +1,6 @@
 const { Logger } = require('logger');
 const { updatePresence } = require('../../common/functions');
+const utils = require('../../utils');
 const { prefix } = require('../../../config/settings.json');
 const logger = new Logger();
 
@@ -16,22 +17,12 @@ const handleMessage = (message, client) => {
   const args = message.content.slice(prefix.length).trim().split(/ +/);
   const command = args.shift().toLowerCase();
 
-  if (!client.commands.has(command)) {
-    return;
-  }
-
   const options = {
     args,
     commands: client.commands
   };
 
-  try {
-    logger.info(`User ${message.member.displayName} issued command ${command} in guild ${message.guild.name}.`);
-    client.commands.get(command).execute(message, options);
-  } catch (err) {
-    logger.error(err);
-    message.reply("there's been a problem executing your command.");
-  }
+  utils.commands.executeCommand(client, message, options, command);
 };
 
 const handleGuildCreate = (guild) => {

--- a/src/utils/commands/index.js
+++ b/src/utils/commands/index.js
@@ -1,0 +1,50 @@
+const { Logger } = require('logger');
+const logger = new Logger();
+
+const validateCommand = (client, message, command) => {
+  const validatedInfo = {
+    type: null,
+    author: null,
+    origin: null
+  };
+
+  if (message.guild) {
+    if (client.commands.guild.has(command)) {
+      validatedInfo.type = 'guild';
+    } else if (client.commands.common.has(command)) {
+      validatedInfo.type = 'common';
+    }
+    validatedInfo.author = message.member.displayName;
+    validatedInfo.origin = message.guild.name;
+  } else {
+    if (client.commands.dm.has(command)) {
+      validatedInfo.type = 'dm';
+    } else if (client.commands.common.has(command)) {
+      validatedInfo.type = 'common';
+    }
+    validatedInfo.author = message.author.username;
+    validatedInfo.origin = 'DM';
+  }
+
+  return validatedInfo;
+};
+
+const executeCommand = (client, message, options, command) => {
+  const { author, type, origin } = validateCommand(client, message, command);
+
+  if (!type) {
+    return;
+  }
+
+  try {
+    logger.info(`User ${author} issued ${type} command ${command} in ${origin}.`);
+    client.commands[type].get(command).execute(message, options);
+  } catch (err) {
+    logger.error(err);
+    message.reply("there's been a problem executing your command.");
+  }
+};
+
+module.exports = {
+  executeCommand
+};

--- a/src/utils/common/common.spec.js
+++ b/src/utils/common/common.spec.js
@@ -1,0 +1,42 @@
+const { splitForMessageEmbedField } = require('./index');
+const { MAX_EMBED_FIELD_SIZE } = require('../../common/constants');
+
+describe('Utils: Common Methods', () => {
+  test('should return an array.', () => {
+    const actualResult = splitForMessageEmbedField();
+    expect(actualResult).toBeInstanceOf(Array);
+  });
+
+  test('should return a non empty array when given a [String] argument.', () => {
+    const actualResult = splitForMessageEmbedField(['Test']);
+    expect(actualResult.length).toBeGreaterThan(0);
+  });
+
+  test('should return an array of strings.', () => {
+    const actualResult = splitForMessageEmbedField();
+    actualResult.forEach((item) => {
+      expect(typeof item).toBe('string');
+    });
+  });
+
+  test('should return an array where the elements are less in size than the limit allowed.', () => {
+    const stringArray = 'string,'.repeat(3).split(',');
+    const longString = 'abc '.repeat(250);
+    stringArray.unshift(longString);
+    const actualResult = splitForMessageEmbedField(stringArray);
+    actualResult.forEach((item) => {
+      expect(item.length).toBeLessThan(MAX_EMBED_FIELD_SIZE);
+    });
+  });
+
+  test('should return an array where its joined elements are equivalent to the joined elements of the argument.', () => {
+    const stringArray = 'string,'.repeat(3).split(',');
+    const longString = 'abc '.repeat(250);
+    const messageWithNewlines = 'this is a message with \n newlines to test \n that newlines are also \n added.';
+    stringArray.unshift(longString);
+    stringArray.push(messageWithNewlines);
+    const actualResult = splitForMessageEmbedField(stringArray).join('');
+    const expectedResult = stringArray.join('');
+    expect(actualResult).toBe(expectedResult);
+  });
+});

--- a/src/utils/common/index.js
+++ b/src/utils/common/index.js
@@ -1,0 +1,40 @@
+const { MAX_EMBED_FIELD_SIZE } = require('../../common/constants');
+
+const splitForMessageEmbedField = (strings = []) => {
+  const splittedStrings = [];
+  let singleMessage = '';
+  let splittedCounter = 0;
+  let stringsCounter = 0;
+
+  while (stringsCounter < strings.length) {
+    const newStringLength = strings[stringsCounter].length;
+    let curStringLength = 0;
+
+    if (newStringLength >= MAX_EMBED_FIELD_SIZE) {
+      throw new Error(`One of the messages is longer than ${MAX_EMBED_FIELD_SIZE} characters.`);
+    }
+
+    if (splittedStrings[splittedCounter]) {
+      curStringLength = splittedStrings[splittedCounter].length;
+    }
+
+    if (curStringLength < MAX_EMBED_FIELD_SIZE - newStringLength) {
+      singleMessage += strings[stringsCounter];
+      stringsCounter++;
+    } else {
+      splittedStrings.push(singleMessage);
+      singleMessage = '';
+      splittedCounter++;
+    }
+  }
+
+  if (singleMessage.length > 0) {
+    splittedStrings.push(singleMessage);
+  }
+
+  return splittedStrings;
+};
+
+module.exports = {
+  splitForMessageEmbedField
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,5 @@
+const commands = require('./commands');
+
+module.exports = {
+  commands
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,7 @@
 const commands = require('./commands');
+const common = require('./common');
 
 module.exports = {
-  commands
+  commands,
+  common
 };


### PR DESCRIPTION
The commands `common`, `dm` and `guild` are just placeholders and should be deleted when the command folder gets populated with the real commands.

The help command currently does not check for gamemaster status or for gamestate. This feature should be done in the future once these concepts are actually applied.